### PR TITLE
Fix namespace when calling some global functions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ gron.BatchDue(exprs, ref)
 To find out when is the cron due next (in near future):
 ```go
 allowCurrent = true // includes current time as well
-nextTime, err := gron.NextTick(expr, allowCurrent) // gives time.Time, error
+nextTime, err := gronx.NextTick(expr, allowCurrent) // gives time.Time, error
 
 // OR, next tick after certain reference time
 refTime = time.Date(2022, time.November, 1, 1, 1, 0, 0, time.UTC)
 allowCurrent = false // excludes the ref time
-nextTime, err := gron.NextTickAfter(expr, refTime, allowCurrent) // gives time.Time, error
+nextTime, err := gronx.NextTickAfter(expr, refTime, allowCurrent) // gives time.Time, error
 ```
 
 ### Prev Tick
@@ -88,12 +88,12 @@ nextTime, err := gron.NextTickAfter(expr, refTime, allowCurrent) // gives time.T
 To find out when was the cron due previously (in near past):
 ```go
 allowCurrent = true // includes current time as well
-prevTime, err := gron.PrevTick(expr, allowCurrent) // gives time.Time, error
+prevTime, err := gronx.PrevTick(expr, allowCurrent) // gives time.Time, error
 
 // OR, prev tick before certain reference time
 refTime = time.Date(2022, time.November, 1, 1, 1, 0, 0, time.UTC)
 allowCurrent = false // excludes the ref time
-nextTime, err := gron.PrevTickBefore(expr, refTime, allowCurrent) // gives time.Time, error
+nextTime, err := gronx.PrevTickBefore(expr, refTime, allowCurrent) // gives time.Time, error
 ```
 
 > The working of `PrevTick*()` and `NextTick*()` are mostly the same except the direction.


### PR DESCRIPTION
Hey!

I noticed that there were some mistakes in readme and some global functions were not called from `gronx` but `gron` which was previously used as a name of a var. 

Cheers,
Damian