### PR TITLE
Fix Windows Build Issue by Splitting Taskify into OS-Specific Files

### DIFF
--- a/pkg/tasker/tasker.go
+++ b/pkg/tasker/tasker.go
@@ -116,38 +116,6 @@ func (t *Tasker) WithContext(ctx context.Context) *Tasker {
 	return t
 }
 
-// Taskify creates TaskFunc out of plain command wrt given options.
-func (t *Tasker) Taskify(cmd string, opt Option) TaskFunc {
-	sh := Shell(opt.Shell)
-
-	return func(ctx context.Context) (int, error) {
-		buf := strings.Builder{}
-		exc := exec.Command(sh[0], sh[1], cmd)
-		exc.Stderr = &buf
-		exc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-		if t.Log.Writer() != exc.Stderr {
-			exc.Stdout = t.Log.Writer()
-		}
-
-		err := exc.Run()
-		if err == nil {
-			return 0, nil
-		}
-
-		for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\r\n"), "\n") {
-			log.Println(ln)
-		}
-
-		code := 1
-		if exErr, ok := err.(*exec.ExitError); ok {
-			code = exErr.ExitCode()
-		}
-
-		return code, err
-	}
-}
-
 // Shell gives a pair of shell and arg.
 // It returns array of string.
 func Shell(shell ...string) []string {

--- a/pkg/tasker/tasker_other.go
+++ b/pkg/tasker/tasker_other.go
@@ -1,4 +1,5 @@
 //go:build !windows
+// +build !windows
 
 package tasker
 

--- a/pkg/tasker/tasker_other.go
+++ b/pkg/tasker/tasker_other.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package tasker
+
+import (
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// Taskify creates TaskFunc out of plain command wrt given options.
+func (t *Tasker) Taskify(cmd string, opt Option) TaskFunc {
+	sh := Shell(opt.Shell)
+
+	return func(ctx context.Context) (int, error) {
+		buf := strings.Builder{}
+		exc := exec.Command(sh[0], sh[1], cmd)
+		exc.Stderr = &buf
+		exc.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+		if t.Log.Writer() != exc.Stderr {
+			exc.Stdout = t.Log.Writer()
+		}
+
+		err := exc.Run()
+		if err == nil {
+			return 0, nil
+		}
+
+		for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\r\n"), "\n") {
+			log.Println(ln)
+		}
+
+		code := 1
+		if exErr, ok := err.(*exec.ExitError); ok {
+			code = exErr.ExitCode()
+		}
+
+		return code, err
+	}
+}

--- a/pkg/tasker/tasker_windows.go
+++ b/pkg/tasker/tasker_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 package tasker
 

--- a/pkg/tasker/tasker_windows.go
+++ b/pkg/tasker/tasker_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package tasker
+
+import (
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// Taskify creates TaskFunc out of plain command wrt given options.
+
+func (t *Tasker) Taskify(cmd string, opt Option) TaskFunc {
+	sh := Shell(opt.Shell)
+
+	return func(ctx context.Context) (int, error) {
+		buf := strings.Builder{}
+		exc := exec.Command(sh[0], sh[1], cmd)
+		exc.Stderr = &buf
+		exc.SysProcAttr = &syscall.SysProcAttr{
+			CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		}
+
+		if t.Log.Writer() != exc.Stderr {
+			exc.Stdout = t.Log.Writer()
+		}
+
+		err := exc.Run()
+		if err == nil {
+			return 0, nil
+		}
+
+		for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\r\n"), "\n") {
+			log.Println(ln)
+		}
+
+		code := 1
+		if exErr, ok := err.(*exec.ExitError); ok {
+			code = exErr.ExitCode()
+		}
+
+		return code, err
+	}
+}


### PR DESCRIPTION
This PR fixes the build issue on Windows caused by a Linux-only syscall in tasker.go.
Windows doesn’t support that syscall, so I adjusted the approach by creating an OS-specific setup for the `Taskify` function.

**Split `tasker.go` by OS**
- `tasker.go`: Keeps the core tasker functionality, minus the `Taskify` function.
- `tasker_windows.go`: Adds a Windows-specific `Taskify` function using `CREATE_NEW_PROCESS_GROUP` to handle process group creation.
- `tasker_other.go`: Retains the original `Taskify` function for Linux and other Unix-like systems.

This way, the build works perfectly on both Windows and Unix-based OS.

Closes #47 