### PR TITLE
Update .goreleaser.yml to Fix GitHub Actions Builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,8 @@
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
 project_name: tasker
 
 release:
@@ -11,41 +16,37 @@ before:
     - go mod tidy
 
 builds:
-  - <<: &build_defaults
-      binary: bin/tasker
-      main: ./cmd/tasker
-      ldflags:
-        - -X main.Version={{.Version}}
-      env:
-        - CGO_ENABLED=0
-    id: macOS
+  - id: macOS
+    binary: bin/tasker
+    main: ./cmd/tasker
+    ldflags:
+      - -X main.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
     goos: [darwin]
     goarch: [amd64, arm64]
 
-  - <<: *build_defaults
-    id: linux
+  - id: linux
+    main: ./cmd/tasker
     goos: [linux]
-    goarch: [386, arm, amd64, arm64]
+    goarch: ["386", arm, amd64, arm64]
 
-  - <<: *build_defaults
-    id: windows
+  - id: windows
+    main: ./cmd/tasker
     goos: [windows]
     goarch: [amd64]
 
 archives:
   - id: nix
     builds: [macOS, linux]
-    <<: &archive_defaults
-      name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
-    rlcp: true
     format: tar.gz
     files:
       - LICENSE
 
   - id: windows
     builds: [windows]
-    <<: *archive_defaults
     wrap_in_directory: false
     format: zip
     files:
@@ -56,7 +57,7 @@ checksum:
   algorithm: sha256
 
 changelog:
-  skip: true
+  disable: true
   use: github
   sort: desc
   filters:


### PR DESCRIPTION
The current [.goreleaser.yml](https://github.com/adhocore/gronx/blob/89f74f2441582c0e29a81e1ea286b119a336bb98/.goreleaser.yml) file uses outdated syntax (version 0), causing GitHub Actions to fail with the error:

> "Only configuration files on version: 2 are supported; yours is version: 0. Please update your configuration."

I’ve updated the config file to match the latest GoReleaser docs. With this fix, all builds run smoothly on Actions, and the binaries are properly attached to releases, making the release process automatic  again.