### PR TITLE
Update GoReleaser archive configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ builds:
 
 archives:
   - id: nix
-    builds: [macOS, linux]
+    ids: [macOS, linux]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     wrap_in_directory: true
     format: tar.gz
@@ -46,7 +46,7 @@ archives:
       - LICENSE
 
   - id: windows
-    builds: [windows]
+    ids: [windows]
     wrap_in_directory: false
     format: zip
     files:


### PR DESCRIPTION
# PR Summary
This small PR updates the GoReleaser configuration to resolve the following warning: 
```
DEPRECATED:  archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```