### PR TITLE
fix: NextTickAfter stuck on DST fall-back (#50)

### DIFF
--- a/next.go
+++ b/next.go
@@ -171,10 +171,18 @@ func bump(ref time.Time, pos int) time.Time {
 		ref = ref.Add(time.Second)
 	case 1:
 		minTime := ref.Add(time.Minute)
-		ref = time.Date(minTime.Year(), minTime.Month(), minTime.Day(), minTime.Hour(), minTime.Minute(), 0, 0, loc)
+		next := time.Date(minTime.Year(), minTime.Month(), minTime.Day(), minTime.Hour(), minTime.Minute(), 0, 0, loc)
+		if !next.After(ref) {
+			next = next.Add(time.Hour)
+		}
+		ref = next
 	case 2:
 		hTime := ref.Add(time.Hour)
-		ref = time.Date(hTime.Year(), hTime.Month(), hTime.Day(), hTime.Hour(), 0, 0, 0, loc)
+		next := time.Date(hTime.Year(), hTime.Month(), hTime.Day(), hTime.Hour(), 0, 0, 0, loc)
+		if !next.After(ref) {
+			next = next.Add(time.Hour)
+		}
+		ref = next
 	case 3, 5:
 		dTime := ref.AddDate(0, 0, 1)
 		ref = time.Date(dTime.Year(), dTime.Month(), dTime.Day(), 0, 0, 0, 0, loc)

--- a/next_test.go
+++ b/next_test.go
@@ -167,3 +167,42 @@ func TestIsUnreachableYearNextTickAfter(t *testing.T) {
 		})
 	}
 }
+
+// https://github.com/adhocore/gronx/issues/50
+func TestNextTickAfterDSTFallBack(t *testing.T) {
+	et, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		cronExpr     string
+		ref          time.Time
+		expectedTime time.Time
+	}{
+		{
+			name:         "every 8h, ambiguous hour skipped by schedule",
+			cronExpr:     "0 */8 * * *",
+			ref:          time.Date(2024, time.November, 3, 0, 30, 0, 0, et),
+			expectedTime: time.Date(2024, time.November, 3, 8, 0, 0, 0, et),
+		},
+		{
+			name:         "daily 12:10 across fall-back",
+			cronExpr:     "10 12 * * *",
+			ref:          time.Date(2024, time.November, 2, 19, 39, 33, 0, et),
+			expectedTime: time.Date(2024, time.November, 3, 12, 10, 0, 0, et),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualTime, err := NextTickAfter(tc.cronExpr, tc.ref, false)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			} else if !actualTime.Equal(tc.expectedTime) {
+				t.Errorf("expected next tick to be %v, got %v", tc.expectedTime, actualTime)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #50.

`NextTickAfter` spins / returns invalid ticks during DST fall-back when the schedule skips the ambiguous wall-clock hour. Repro: `"0 */8 * * *"` from `2024-11-03 00:30 EDT` in `America/New_York` returns `01:00 EDT` (which `IsDue` then says false on), and the next call errors with `"tried so hard"`.

`bump()` for the hour case reconstructs via `time.Date(...)`, which picks the first occurrence of an ambiguous wall hour — same hour as `ref`, so the bump advances 0s in UTC and `bumpUntilDue` spins. Same shape in the minute case.

Fix asserts the bump moved forward and corrects with `+1h` if not.

Scoped to hour + minute only since those are the cases that fire in any DST zone. Day/month/year reconstruct at midnight and would only be affected in midnight-DST zones — happy to follow up with a defense-in-depth pass if you want.

Test added covering the ambiguous-hour skip and the original `"tried so hard"` repro from #50.