### PR TITLE
Fix next tick for a day-of-month that skips short months

### DIFF
--- a/next.go
+++ b/next.go
@@ -143,7 +143,11 @@ func isUnreachableYear(year string, ref time.Time, reverse bool) bool {
 	return true
 }
 
-var limit = map[int]int{0: 60, 1: 60, 2: 24, 3: 31, 4: 12, 5: 366, 6: 100}
+// The day-of-month bump advances one day at a time, so its limit must be large
+// enough to cross a short month and still reach a high day like the 31st: two
+// consecutive occurrences of the 31st are up to 61 days apart (e.g. Aug 31 to
+// Oct 31), so 31 was too small and left the search on an overflow date.
+var limit = map[int]int{0: 60, 1: 60, 2: 24, 3: 62, 4: 12, 5: 366, 6: 100}
 
 func bumpUntilDue(c Checker, segment string, pos int, ref time.Time, reverse bool) (time.Time, bool, error) {
 	// <second> <minute> <hour> <day> <month> <weekday> <year>

--- a/next_test.go
+++ b/next_test.go
@@ -37,6 +37,18 @@ func TestNextTickAfter(t *testing.T) {
 			}
 		})
 
+		t.Run("day of month skips months without that day", func(t *testing.T) {
+			// After Jan 31 the next 31st is Mar 31, not an overflow of February.
+			ref, _ := time.Parse(FullDateFormat, "2021-01-31 00:00:00")
+			next, err := NextTickAfter("0 0 31 * *", ref, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := next.Format("2006-01-02"); got != "2021-03-31" {
+				t.Errorf("next 31st after 2021-01-31 should be 2021-03-31, got %s", got)
+			}
+		})
+
 		for i, test := range testcases() {
 			t.Run(fmt.Sprintf("next run after incl #%d: %s", i, test.Expr), func(t *testing.T) {
 				ref, _ := time.Parse(FullDateFormat, test.Ref)


### PR DESCRIPTION
`NextTickAfter` returns a wrong (overflow) date when the day-of-month field names a day the next month doesn't have:

```
NextTickAfter("0 0 31 * *", 2021-01-31)  ->  2021-03-04   // want 2021-03-31
IsDue("0 0 31 * *", 2021-03-04)          ->  false        // its own matcher rejects it
```

The day search advances one day at a time but was capped at 31 iterations — too small to cross a short month (February) and reach the 31st, so it stopped on an overflow date. Two consecutive 31sts are up to 61 days apart, so the cap needs to be ~62. Raising it makes `0 0 31 * *` return Mar 31, May 31, … and makes impossible dates like `0 0 31 4 *` error instead of firing on the wrong day.

Relates to #55, which reports the Feb-29 form of this.
