### PR TITLE
Fix weekday step range ending in 7 skipping Sunday

### DIFF
--- a/checker.go
+++ b/checker.go
@@ -67,7 +67,7 @@ func (c *SegmentChecker) isOffsetDue(offset string, val, pos int) (bool, error) 
 
 	bounds, isWeekDay := boundsByPos(pos), pos == 5
 	if strings.Contains(offset, "/") {
-		return inStep(val, offset, bounds)
+		return inStep(val, offset, bounds, isWeekDay)
 	}
 	if strings.Contains(offset, "-") {
 		return inRange(val, offset, bounds, isWeekDay)

--- a/next_test.go
+++ b/next_test.go
@@ -49,6 +49,19 @@ func TestNextTickAfter(t *testing.T) {
 			}
 		})
 
+		t.Run("weekday step range ending in 7 matches Sunday", func(t *testing.T) {
+			// 4-7/3 in the weekday field is {Thu, Sun}. 7 is an alias for Sunday,
+			// whose time.Weekday() value is 0, so Sun 2032-05-02 must not be skipped.
+			ref, _ := time.Parse(FullDateFormat, "2032-05-01 00:00:00")
+			next, err := NextTickAfter("0 0 * * 4-7/3", ref, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := next.Format("2006-01-02"); got != "2032-05-02" {
+				t.Errorf("next 4-7/3 weekday after 2032-05-01 should be Sun 2032-05-02, got %s", got)
+			}
+		})
+
 		for i, test := range testcases() {
 			t.Run(fmt.Sprintf("next run after incl #%d: %s", i, test.Expr), func(t *testing.T) {
 				ref, _ := time.Parse(FullDateFormat, test.Ref)

--- a/validator.go
+++ b/validator.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func inStep(val int, s string, bounds []int) (bool, error) {
+func inStep(val int, s string, bounds []int, isWeekDay bool) (bool, error) {
 	parts := strings.Split(s, "/")
 	step, err := strconv.Atoi(parts[1])
 	if err != nil {
@@ -40,6 +40,20 @@ func inStep(val int, s string, bounds []int) (bool, error) {
 
 	if (len(sub) > 1 && end < start) || start < bounds[0] || end > bounds[1] {
 		return false, fmt.Errorf("step '%s' out of bounds(%d, %d)", parts[0], bounds[0], bounds[1])
+	}
+
+	if isWeekDay {
+		// 7 is an alias for Sunday (0), same as inRange. A leading 7 ("7/step")
+		// starts the sequence at Sunday, so normalize it to 0.
+		if start == 7 && end != 7 {
+			start = 0
+		}
+		// time.Weekday() reports Sunday as 0, but a step whose range ends at 7
+		// (e.g. "4-7/3") expresses it as 7. Sunday is due if either form lands
+		// on the step, and checking both keeps "0-7/2" (0 already in range) working.
+		if val == 0 {
+			return inStepRange(0, start, end, step) || inStepRange(7, start, end, step), nil
+		}
 	}
 
 	return inStepRange(val, start, end, step), nil


### PR DESCRIPTION
`4-7/3` in the weekday field means {Thu, Sun}, but it never matched Sunday. `inRange` treats 7 as an alias for Sunday; `inStep` doesn't, and stepped ranges go through `inStep`. `time.Weekday()` returns 0 for Sunday, so `inStepRange` checked 0 against an endpoint of 7 and never matched — `NextTickAfter` skipped every Sunday (`7/step` skipped almost a year).

This adds the same alias handling to `inStep`, testing both the 0 and 7 forms so `0-7/step` (0 already in range) still works. Existing tests pass; the added test fails without the fix.
